### PR TITLE
fix: unblock and harden v0.9.5 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
             id: windows-x64
             os: windows-latest
             runtime_targets: win-x64
+            packaged_runtime_checks: win-x64=release/win-unpacked/resources/sing-box
             builder_args: --win nsis portable --x64
             artifact_path: |
               release/StonePlus-*-windows-x64-setup.exe
@@ -75,6 +76,7 @@ jobs:
             id: linux-x64
             os: ubuntu-latest
             runtime_targets: linux-x64
+            packaged_runtime_checks: linux-x64=release/linux-unpacked/resources/sing-box
             builder_args: --linux AppImage deb --x64
             artifact_path: |
               release/StonePlus-*-linux-x86_64.AppImage
@@ -84,6 +86,7 @@ jobs:
             id: linux-arm64
             os: ubuntu-24.04-arm
             runtime_targets: linux-arm64
+            packaged_runtime_checks: linux-arm64=release/linux-arm64-unpacked/resources/sing-box
             builder_args: --linux AppImage deb --arm64
             artifact_path: |
               release/StonePlus-*-linux-arm64.AppImage
@@ -93,6 +96,7 @@ jobs:
             id: macos
             os: macos-15
             runtime_targets: mac-x64 mac-arm64
+            packaged_runtime_checks: mac-x64=release/mac/Stone+.app/Contents/Resources/sing-box mac-arm64=release/mac-arm64/Stone+.app/Contents/Resources/sing-box
             builder_args: --mac dmg zip --x64 --arm64 --config.mac.identity=- --config.mac.hardenedRuntime=false
             artifact_path: |
               release/StonePlus-*-macos-x64.dmg
@@ -160,17 +164,33 @@ jobs:
           --config.extraMetadata.author.email=${{ github.repository_owner }}@users.noreply.github.com
           --config.linux.maintainer=${{ github.repository_owner }}@users.noreply.github.com
 
-      - name: Verify Windows signatures and packaged core
+      - name: Verify packaged sing-box runtime
+        shell: pwsh
+        run: |
+          $checks = '${{ matrix.packaged_runtime_checks }}'.Split(' ', [StringSplitOptions]::RemoveEmptyEntries)
+          foreach ($check in $checks) {
+            $parts = $check.Split('=', 2)
+            if ($parts.Count -ne 2) {
+              throw "Invalid packaged runtime check: $check"
+            }
+            $target = $parts[0]
+            $root = $parts[1]
+            node scripts/verify-sing-box-runtime.mjs --target $target --runtime-root $root --manifest-root $root --require-executable
+            if ($LASTEXITCODE -ne 0) {
+              throw "Packaged sing-box runtime verification failed for $target."
+            }
+            node scripts/smoke-sing-box-runtime.mjs --target $target --runtime-root $root --manifest-root $root
+            if ($LASTEXITCODE -ne 0) {
+              throw "Packaged sing-box runtime smoke test failed for $target."
+            }
+          }
+
+      - name: Verify Windows signatures
         if: matrix.id == 'windows-x64'
         shell: pwsh
         env:
           WIN_SIGNING_CERT_SHA1: ${{ vars.WIN_SIGNING_CERT_SHA1 }}
         run: |
-          node scripts/verify-sing-box-runtime.mjs --target win-x64 --runtime-root release/win-unpacked/resources/sing-box
-          if ($LASTEXITCODE -ne 0) {
-            throw 'The packaged sing-box runtime no longer matches its pinned manifest.'
-          }
-
           $expectedThumbprint = $env:WIN_SIGNING_CERT_SHA1.Replace(' ', '').ToUpperInvariant()
           $signedFiles = @(
             'release/win-unpacked/Stone+.exe',
@@ -213,6 +233,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.26.4'
+          cache: false
 
       - name: Prepare pinned corresponding source
         shell: pwsh

--- a/scripts/prepare-sing-box-source.ps1
+++ b/scripts/prepare-sing-box-source.ps1
@@ -113,6 +113,7 @@ try {
     'build\sing-box\runtime-manifest.json',
     'scripts\fetch-sing-box.ps1',
     'scripts\verify-sing-box-runtime.mjs',
+    'scripts\smoke-sing-box-runtime.mjs',
     'scripts\electron-builder-before-pack.mjs',
     'scripts\prepare-sing-box-source.ps1'
   )) {

--- a/scripts/smoke-sing-box-runtime.mjs
+++ b/scripts/smoke-sing-box-runtime.mjs
@@ -1,0 +1,217 @@
+import { execFile as execFileCallback, spawn } from 'node:child_process'
+import { once } from 'node:events'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { createConnection, createServer } from 'node:net'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { fileURLToPath } from 'node:url'
+import { verifyRuntimeTarget } from './verify-sing-box-runtime.mjs'
+
+const execFile = promisify(execFileCallback)
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url))
+const repositoryRoot = path.resolve(scriptDirectory, '..')
+const defaultManifestRoot = path.join(repositoryRoot, 'build', 'sing-box')
+
+function readOption(args, optionName) {
+  const index = args.indexOf(optionName)
+  if (index === -1) return undefined
+  if (!args[index + 1]) throw new Error(`${optionName} requires a value.`)
+  return args[index + 1]
+}
+
+function runtimeEnvironment(runtimePath) {
+  const environment = { ...process.env }
+  const append = (name) => {
+    environment[name] = environment[name]
+      ? `${runtimePath}${path.delimiter}${environment[name]}`
+      : runtimePath
+  }
+  append('PATH')
+  if (process.platform === 'linux') append('LD_LIBRARY_PATH')
+  if (process.platform === 'darwin') append('DYLD_LIBRARY_PATH')
+  return environment
+}
+
+async function freeLoopbackPort() {
+  const server = createServer()
+  server.unref()
+  await new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address()
+  if (!address || typeof address === 'string') throw new Error('Unable to reserve a loopback port.')
+  await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()))
+  return address.port
+}
+
+function probeLoopbackPort(port, timeoutMs = 250) {
+  return new Promise((resolve, reject) => {
+    const socket = createConnection({ host: '127.0.0.1', port })
+    const finish = (error) => {
+      socket.removeAllListeners()
+      socket.destroy()
+      if (error) reject(error)
+      else resolve()
+    }
+    socket.setTimeout(timeoutMs, () => finish(new Error(`Port ${port} probe timed out.`)))
+    socket.once('connect', () => finish())
+    socket.once('error', finish)
+  })
+}
+
+async function waitForPorts(child, ports, shouldBeOpen, timeoutMs) {
+  const deadline = Date.now() + timeoutMs
+  let lastError
+  while (Date.now() < deadline) {
+    if (shouldBeOpen && (child.exitCode !== null || child.signalCode !== null)) {
+      throw new Error(`sing-box exited before its loopback listeners became ready (${child.exitCode ?? child.signalCode}).`)
+    }
+    const results = await Promise.allSettled(ports.map((port) => probeLoopbackPort(port)))
+    const matches = shouldBeOpen
+      ? results.every((result) => result.status === 'fulfilled')
+      : results.every((result) => result.status === 'rejected')
+    if (matches) return
+    lastError = results.find((result) => result.status === 'rejected')?.reason
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  throw new Error(`sing-box loopback listeners did not become ${shouldBeOpen ? 'ready' : 'closed'} in time.`, {
+    cause: lastError,
+  })
+}
+
+function waitForExit(child, timeoutMs) {
+  return new Promise((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve(true)
+      return
+    }
+    const onExit = () => {
+      clearTimeout(timer)
+      resolve(true)
+    }
+    const timer = setTimeout(() => {
+      child.off('exit', onExit)
+      resolve(false)
+    }, timeoutMs)
+    child.once('exit', onExit)
+  })
+}
+
+async function terminateChild(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return
+  child.kill('SIGTERM')
+  if (await waitForExit(child, 5_000)) return
+
+  if (process.platform === 'win32' && child.pid) {
+    await execFile('taskkill', ['/pid', String(child.pid), '/T', '/F'], { windowsHide: true }).catch(() => undefined)
+  } else if (child.pid) {
+    try { process.kill(-child.pid, 'SIGKILL') } catch { child.kill('SIGKILL') }
+  }
+  if (!await waitForExit(child, 5_000)) throw new Error('sing-box did not exit after forced termination.')
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  const targetName = readOption(args, '--target')
+  const runtimeRoot = readOption(args, '--runtime-root')
+  const selectedManifestRoot = path.resolve(readOption(args, '--manifest-root') ?? defaultManifestRoot)
+  if (!targetName || !runtimeRoot) throw new Error('--target and --runtime-root are required.')
+
+  const verified = await verifyRuntimeTarget(targetName, {
+    runtimeRoot,
+    manifestRoot: selectedManifestRoot,
+    requireExecutable: true,
+  })
+  const manifest = JSON.parse(await readFile(path.join(selectedManifestRoot, 'runtime-manifest.json'), 'utf8'))
+  const target = manifest.targets?.[targetName]
+  if (!target?.executable) throw new Error(`Missing executable metadata for ${targetName}.`)
+  const executablePath = path.join(verified.runtimeRoot, target.executable)
+  const environment = runtimeEnvironment(verified.runtimeRoot)
+
+  const versionResult = await execFile(executablePath, ['version'], {
+    cwd: verified.runtimeRoot,
+    env: environment,
+    timeout: 10_000,
+    windowsHide: true,
+  })
+  const versionOutput = `${versionResult.stdout}\n${versionResult.stderr}`
+  if (!new RegExp(`\\bsing-box\\s+version\\s+${verified.version.replaceAll('.', '\\.')}(?:\\s|$)`, 'i').test(versionOutput)) {
+    throw new Error(`Unexpected sing-box version output for ${targetName}.`)
+  }
+
+  const temporaryRoot = await mkdtemp(path.join(tmpdir(), 'stone-sing-box-smoke-'))
+  const mixedPort = await freeLoopbackPort()
+  let controllerPort = await freeLoopbackPort()
+  while (controllerPort === mixedPort) controllerPort = await freeLoopbackPort()
+  const configPath = path.join(temporaryRoot, 'config.json')
+  const config = {
+    log: { level: 'warn', timestamp: true },
+    inbounds: [{
+      type: 'mixed',
+      tag: 'stone-release-smoke-mixed',
+      listen: '127.0.0.1',
+      listen_port: mixedPort,
+    }],
+    outbounds: [{ type: 'direct', tag: 'direct' }],
+    route: { final: 'direct' },
+    experimental: {
+      clash_api: {
+        external_controller: `127.0.0.1:${controllerPort}`,
+        secret: 'stone-release-smoke-controller-key',
+      },
+    },
+  }
+  await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 })
+
+  let child
+  let output = ''
+  try {
+    await execFile(executablePath, ['check', '-c', configPath], {
+      cwd: verified.runtimeRoot,
+      env: environment,
+      timeout: 15_000,
+      windowsHide: true,
+    })
+    child = spawn(executablePath, ['run', '-c', configPath], {
+      cwd: verified.runtimeRoot,
+      env: environment,
+      windowsHide: true,
+      detached: process.platform !== 'win32',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    for (const stream of [child.stdout, child.stderr]) {
+      stream?.on('data', (chunk) => {
+        output = `${output}${chunk}`.slice(-8_000)
+      })
+    }
+    await once(child, 'spawn')
+    await waitForPorts(child, [mixedPort, controllerPort], true, 10_000)
+    const pid = child.pid
+    await terminateChild(child)
+    await waitForPorts(child, [mixedPort, controllerPort], false, 5_000)
+    if (pid) {
+      let alive = true
+      try {
+        process.kill(pid, 0)
+      } catch (error) {
+        if (error && typeof error === 'object' && 'code' in error && error.code === 'ESRCH') alive = false
+        else throw error
+      }
+      if (alive) throw new Error(`sing-box process ${pid} remained alive after shutdown.`)
+    }
+    process.stdout.write(`Smoke-tested sing-box ${verified.version} runtime: ${targetName}\n`)
+  } catch (error) {
+    if (output) process.stderr.write(`${output}\n`)
+    throw error
+  } finally {
+    if (child) await terminateChild(child).catch(() => undefined)
+    await rm(temporaryRoot, { recursive: true, force: true })
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : error)
+  process.exitCode = 1
+})

--- a/scripts/verify-sing-box-runtime.mjs
+++ b/scripts/verify-sing-box-runtime.mjs
@@ -10,10 +10,6 @@ const manifestRoot = path.join(repositoryRoot, 'build', 'sing-box')
 const defaultRuntimeRoot = manifestRoot
 const supportedTargets = ['win-x64', 'linux-x64', 'linux-arm64', 'mac-x64', 'mac-arm64']
 
-async function readJson(filePath) {
-  return JSON.parse(await readFile(filePath, 'utf8'))
-}
-
 function assertSafeRelativePath(relativePath) {
   if (typeof relativePath !== 'string' || relativePath.length === 0 || relativePath.includes('\\')) {
     throw new Error(`Invalid portable runtime path: ${String(relativePath)}`)
@@ -44,7 +40,7 @@ async function collectFiles(directory, prefix = '') {
     if (metadata.isDirectory()) {
       files.push(...await collectFiles(absolutePath, relativePath))
     } else if (metadata.isFile()) {
-      files.push({ relativePath, absolutePath, size: metadata.size })
+      files.push({ relativePath, absolutePath, size: metadata.size, mode: metadata.mode })
     } else {
       throw new Error(`Runtime contains an unsupported filesystem entry: ${relativePath}`)
     }
@@ -66,8 +62,21 @@ export async function verifyRuntimeTarget(targetName, options = {}) {
     throw new Error(`Unsupported sing-box runtime target: ${targetName}`)
   }
   const runtimeRoot = path.resolve(options.runtimeRoot ?? defaultRuntimeRoot)
-  const runtimeManifest = await readJson(path.join(manifestRoot, 'runtime-manifest.json'))
-  const distributionManifest = await readJson(path.join(manifestRoot, 'distribution-manifest.json'))
+  const selectedManifestRoot = path.resolve(options.manifestRoot ?? manifestRoot)
+  const manifestNames = ['runtime-manifest.json', 'distribution-manifest.json']
+  const canonicalManifestContents = await Promise.all(manifestNames.map((name) => (
+    readFile(path.join(manifestRoot, name))
+  )))
+  const selectedManifestContents = selectedManifestRoot === manifestRoot
+    ? canonicalManifestContents
+    : await Promise.all(manifestNames.map((name) => readFile(path.join(selectedManifestRoot, name))))
+  for (let index = 0; index < manifestNames.length; index += 1) {
+    if (!canonicalManifestContents[index].equals(selectedManifestContents[index])) {
+      throw new Error(`Packaged sing-box manifest differs from the pinned source: ${manifestNames[index]}`)
+    }
+  }
+  const runtimeManifest = JSON.parse(selectedManifestContents[0].toString('utf8'))
+  const distributionManifest = JSON.parse(selectedManifestContents[1].toString('utf8'))
 
   if (runtimeManifest.schemaVersion !== 1 || distributionManifest.schemaVersion !== 1) {
     throw new Error('Unsupported sing-box manifest schema.')
@@ -132,6 +141,12 @@ export async function verifyRuntimeTarget(targetName, options = {}) {
     if (await sha256(actualFile.absolutePath) !== expectedFile.sha256) {
       throw new Error(`SHA-256 mismatch for ${targetName}/${actualFile.relativePath}.`)
     }
+    if (options.requireExecutable
+      && !targetName.startsWith('win-')
+      && actualFile.relativePath === target.executable
+      && (actualFile.mode & 0o111) === 0) {
+      throw new Error(`Packaged sing-box executable is not executable: ${targetName}/${actualFile.relativePath}`)
+    }
   }
 
   return { targetName, runtimeRoot: targetRoot, version: runtimeManifest.version }
@@ -147,10 +162,16 @@ function readOption(args, optionName) {
 async function main() {
   const args = process.argv.slice(2)
   const runtimeRoot = readOption(args, '--runtime-root')
+  const selectedManifestRoot = readOption(args, '--manifest-root')
+  const requireExecutable = args.includes('--require-executable')
   const selectedTarget = readOption(args, '--target')
   const targets = args.includes('--all') ? supportedTargets : [selectedTarget ?? runtimeTargetName()]
   for (const targetName of targets) {
-    const result = await verifyRuntimeTarget(targetName, { runtimeRoot })
+    const result = await verifyRuntimeTarget(targetName, {
+      runtimeRoot,
+      manifestRoot: selectedManifestRoot,
+      requireExecutable,
+    })
     process.stdout.write(`Verified sing-box ${result.version} runtime: ${result.targetName}\n`)
   }
 }

--- a/src/main/gateway/scheduler.ts
+++ b/src/main/gateway/scheduler.ts
@@ -128,7 +128,10 @@ const TRANSPORT_FALLBACK_FLOOR_MS = 3_000
 const CONCURRENT_STICKY_SESSION_PENALTY = 120
 
 export class NoEligibleAccountError extends Error {
-  constructor(message = 'No eligible account is available for this request') {
+  constructor(
+    readonly accountIds: readonly string[] = [],
+    message = 'No eligible account is available for this request'
+  ) {
     super(message)
     this.name = 'NoEligibleAccountError'
   }
@@ -303,7 +306,10 @@ export class PoolScheduler {
       ? verifiedCandidates
       : sourceEligibility.unknown.filter(runtimeEligible)
     if (candidates.length === 0) {
-      throw new NoEligibleAccountError()
+      throw new NoEligibleAccountError([
+        ...sourceEligibility.verified.map((account) => account.id),
+        ...sourceEligibility.unknown.map((account) => account.id),
+      ])
     }
 
     const stickyKey = pool.stickySessions && sessionId ? `${pool.id}:${sessionId}` : undefined

--- a/src/main/gateway/server.ts
+++ b/src/main/gateway/server.ts
@@ -906,7 +906,22 @@ export class GatewayServer implements GatewayController {
               requiredCapabilities
             })
           } catch (error) {
-            if (error instanceof NoEligibleAccountError && lastRetryableError) throw lastRetryableError
+            if (error instanceof NoEligibleAccountError) {
+              // Report only the statically compatible source set. The desktop
+              // layer filters this down to recoverable disabled/failure-cooled
+              // accounts and applies per-account single-flight throttling, so
+              // retry exhaustion can recover a stale sibling without turning
+              // repeated 503s into a probe storm.
+              if (error.accountIds.length > 0) {
+                this.emitRuntimeState({
+                  noEligibleAccounts: {
+                    poolId: pool.id,
+                    accountIds: error.accountIds,
+                  },
+                })
+              }
+              if (lastRetryableError) throw lastRetryableError
+            }
             throw error
           } finally {
             schedulerSelectMs = Math.max(0, this.now() - schedulerSelectStarted)

--- a/src/main/gateway/types.ts
+++ b/src/main/gateway/types.ts
@@ -69,6 +69,16 @@ export interface GatewayRuntimeStateUpdate {
   gatewayStatus?: boolean
   accountIds?: readonly string[]
   allAccounts?: boolean
+  /**
+   * Static model/capability matching succeeded, but every matching source was
+   * unavailable at scheduling time. The desktop layer may use this narrow set
+   * to re-probe stale disabled/cooldown state without scanning unrelated
+   * accounts or treating concurrency saturation as an account failure.
+   */
+  noEligibleAccounts?: {
+    poolId: string
+    accountIds: readonly string[]
+  }
 }
 
 export type GatewayRuntimeStateHandler = (update: GatewayRuntimeStateUpdate) => void

--- a/src/main/ipc/gateway-api.ts
+++ b/src/main/ipc/gateway-api.ts
@@ -94,6 +94,7 @@ export function registerGatewayApi(
   const runtimeDeltaPublishIntervalMs = 50
   const accountStateFlushDelayMs = 250
   const requestLogCheckpointIntervalMs = 10_000
+  const noEligibleProbeCooldownMs = 30_000
   let scheduledRuntimeDeltaPublish: ReturnType<typeof setTimeout> | undefined
   let scheduledRequestLogCheckpoint: ReturnType<typeof setTimeout> | undefined
   let lastRuntimeDeltaPublishAt: number | undefined
@@ -117,7 +118,11 @@ export function registerGatewayApi(
   const apiSourceCapabilityProbeOwners = new Map<string, symbol>()
   let automaticCooldownRefreshTriggered = false
   let automaticCooldownRefreshFlight: Promise<void> | undefined
+  const noEligibleProbeFlights = new Map<string, Promise<void>>()
+  const noEligibleProbeLastStartedAt = new Map<string, number>()
+  const noEligibleRefreshFlights = new Set<Promise<void>>()
   let evaluateAutomaticCooldownRefresh = (): void => undefined
+  let refreshNoEligibleAccounts = (_accountIds: readonly string[]): void => undefined
   let gatewayLifecycleTail: Promise<void> = Promise.resolve()
   const enqueueGatewayLifecycle = <T>(operation: () => Promise<T>): Promise<T> => {
     const result = gatewayLifecycleTail.then(operation, operation)
@@ -383,6 +388,9 @@ export function registerGatewayApi(
   }
 
   const unsubscribeRuntimeState = gateway.onRuntimeState((update = { gatewayStatus: true, allAccounts: true }) => {
+    if (update.noEligibleAccounts?.accountIds.length) {
+      refreshNoEligibleAccounts(update.noEligibleAccounts.accountIds)
+    }
     if (update.allAccounts) {
       scheduleRuntimeDelta({ gatewayStatus: update.gatewayStatus === true, allAccounts: true })
     } else if (update.accountIds?.length) {
@@ -657,6 +665,47 @@ export function registerGatewayApi(
     }).finally(() => {
       if (automaticCooldownRefreshFlight === flight) automaticCooldownRefreshFlight = undefined
       evaluateAutomaticCooldownRefresh()
+    })
+  }
+
+  refreshNoEligibleAccounts = (accountIds: readonly string[]): void => {
+    if (closed) return
+    const now = Date.now()
+    const candidates = [...new Set(accountIds)].filter((accountId) => {
+      const account = store.getRuntimeAccount(accountId)
+      if (!account || account.status === 'expired' || account.status === 'checking') return false
+      // Active sources can be absent only because of concurrency or an
+      // in-memory circuit decision. Neither is evidence that a credential
+      // probe is useful. Known quota cooldowns have their own reset timer.
+      if (account.status === 'disabled') return true
+      if (account.status !== 'cooldown') return false
+      return account.cooldownReason !== 'quota' && !quotaExhausted(account)
+    }).filter((accountId) => {
+      const lastStartedAt = noEligibleProbeLastStartedAt.get(accountId)
+      return !noEligibleProbeFlights.has(accountId)
+        && (lastStartedAt === undefined || now - lastStartedAt >= noEligibleProbeCooldownMs)
+    })
+    if (candidates.length === 0) return
+
+    const refreshFlight = mapConcurrent(candidates, 3, async (accountId) => {
+      const existing = noEligibleProbeFlights.get(accountId)
+      if (existing) return existing
+      noEligibleProbeLastStartedAt.set(accountId, Date.now())
+      const probeFlight = probeAndPersistAccount(accountId).then(() => undefined)
+      noEligibleProbeFlights.set(accountId, probeFlight)
+      try {
+        await probeFlight
+      } finally {
+        if (noEligibleProbeFlights.get(accountId) === probeFlight) {
+          noEligibleProbeFlights.delete(accountId)
+        }
+      }
+    }).then(() => undefined)
+    noEligibleRefreshFlights.add(refreshFlight)
+    void refreshFlight.catch((error: unknown) => {
+      console.error('Stone+ could not refresh accounts after a zero-candidate schedule', error)
+    }).finally(() => {
+      noEligibleRefreshFlights.delete(refreshFlight)
     })
   }
 
@@ -2388,6 +2437,10 @@ export function registerGatewayApi(
     if (automaticCooldownRefreshFlight) {
       await Promise.allSettled([automaticCooldownRefreshFlight])
     }
+    await Promise.allSettled([...noEligibleRefreshFlights, ...noEligibleProbeFlights.values()])
+    noEligibleRefreshFlights.clear()
+    noEligibleProbeFlights.clear()
+    noEligibleProbeLastStartedAt.clear()
     if (ownsOutboundReloadCoordinator) await outboundReloadCoordinator.close()
     else await outboundReloadCoordinator.settle()
     const oauthCompletions = new Set<Promise<unknown>>(oauthCompletionFlights)

--- a/tests/client-instances/client-instance-manager.test.ts
+++ b/tests/client-instances/client-instance-manager.test.ts
@@ -9,6 +9,8 @@ import {
   type ClientInstanceProcess,
 } from '../../src/main/client-instances'
 
+const expectedDefaultLaunchMode = process.platform === 'win32' ? 'terminal' : 'background'
+
 class MemoryMetadata {
   readonly values = new Map<string, string>()
   writes = 0
@@ -86,11 +88,16 @@ describe('ClientInstanceManager', () => {
     })
     const id = instances[0].id
     instances = await manager.start(id)
-    expect(instances[0]).toMatchObject({ status: 'running', pid: 4242, launchMode: 'terminal', processAlive: true })
+    expect(instances[0]).toMatchObject({
+      status: 'running',
+      pid: 4242,
+      launchMode: expectedDefaultLaunchMode,
+      processAlive: true
+    })
     expect(spawn).toHaveBeenCalledWith(executable, ['--search'], expect.objectContaining({
       cwd: workingDirectory,
       env: expect.objectContaining({ CODEX_HOME: configDirectory, OPENAI_BASE_URL: 'http://127.0.0.1:15721/v1' }),
-      launchMode: 'terminal'
+      launchMode: expectedDefaultLaunchMode
     }))
     await manager.stop(id)
     await vi.waitFor(() => expect(manager.list()[0].status).toBe('stopped'))
@@ -131,7 +138,7 @@ describe('ClientInstanceManager', () => {
     })
   })
 
-  it('keeps legacy definitions in background mode while new instances default to terminal mode', async () => {
+  it('keeps legacy definitions in background mode while new instances use the platform-safe default', async () => {
     const root = await mkdtemp(join(tmpdir(), 'stone-client-instance-legacy-'))
     directories.push(root)
     const metadata = new MemoryMetadata()
@@ -142,7 +149,7 @@ describe('ClientInstanceManager', () => {
     const manager = new ClientInstanceManager({ store: metadata })
     expect(manager.initialize()[0].launchMode).toBe('background')
     const created = await manager.save({ name: 'New', client: 'codex', configDirectory: root })
-    expect(created.find((item) => item.name === 'New')?.launchMode).toBe('terminal')
+    expect(created.find((item) => item.name === 'New')?.launchMode).toBe(expectedDefaultLaunchMode)
   })
 
   it('coalesces concurrent starts and ignores renderer listener failures', async () => {

--- a/tests/gateway/server.test.ts
+++ b/tests/gateway/server.test.ts
@@ -4,7 +4,7 @@ import { EventEmitter } from 'node:events'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Account, GatewaySettings, Pool, ProviderDefinition, RequestLog, Route } from '../../src/shared/types'
 import { createCanonicalStreamParser, GatewayServer } from '../../src/main/gateway'
-import type { GatewayConfig } from '../../src/main/gateway'
+import type { GatewayConfig, GatewayRuntimeStateUpdate } from '../../src/main/gateway'
 
 const timestamp = 1_700_000_000_000
 const runningServers: GatewayServer[] = []
@@ -316,6 +316,35 @@ afterEach(async () => {
 })
 
 describe('GatewayServer', () => {
+  it('reports the statically matching accounts when scheduling has zero runtime candidates', async () => {
+    const port = await freePort()
+    const gatewayConfig = config(port)
+    gatewayConfig.accounts.forEach((candidate) => {
+      candidate.status = 'disabled'
+    })
+    const runtimeUpdates: GatewayRuntimeStateUpdate[] = []
+    const upstreamFetch = vi.fn()
+    const gateway = new GatewayServer({
+      config: gatewayConfig,
+      credentialResolver: () => 'credential',
+      fetchImplementation: upstreamFetch as typeof fetch,
+    })
+    gateway.onRuntimeState((update) => runtimeUpdates.push(update))
+    runningServers.push(gateway)
+    await gateway.start()
+
+    const response = await post(port)
+    expect(response.status).toBe(503)
+    await response.text()
+    expect(upstreamFetch).not.toHaveBeenCalled()
+    expect(runtimeUpdates).toContainEqual(expect.objectContaining({
+      noEligibleAccounts: {
+        poolId: 'pool',
+        accountIds: ['first', 'second'],
+      },
+    }))
+  })
+
   it('captures replay payloads only when enabled and exposes a content-redacted template', async () => {
     const port = await freePort()
     const gatewayConfig = config(port, { logPayloads: true })

--- a/tests/ipc/gateway-api.test.ts
+++ b/tests/ipc/gateway-api.test.ts
@@ -1310,6 +1310,64 @@ describe('refresh provider models IPC', () => {
     expect(upstreamFetch).toHaveBeenCalledTimes(2)
   })
 
+  it('rechecks a disabled matching account once when the scheduler has no candidates', async () => {
+    const disabled = {
+      ...apiKeyAccount(),
+      status: 'disabled' as const,
+      circuitState: 'open' as const,
+      lastError: 'Stale disabled classification',
+    }
+    const active = {
+      ...apiKeyAccount(),
+      id: 'account-active',
+      credentialId: 'credential-active',
+    }
+    let resolveProbe!: (response: Response) => void
+    const upstreamFetch = vi.fn(() => new Promise<Response>((resolve) => {
+      resolveProbe = resolve
+    }))
+    const harness = createHarness(
+      [disabled, active],
+      {
+        [disabled.credentialId]: 'sk-disabled',
+        [active.credentialId]: 'sk-active',
+      },
+      upstreamFetch,
+    )
+    const update: GatewayRuntimeStateUpdate = {
+      noEligibleAccounts: {
+        poolId: 'pool',
+        accountIds: [disabled.id, active.id],
+      },
+    }
+
+    harness.emitRuntimeState(update)
+    harness.emitRuntimeState(update)
+    await vi.waitFor(() => expect(upstreamFetch).toHaveBeenCalledOnce())
+    expect(harness.store.setAccountCheckResult).toHaveBeenCalledWith(
+      disabled.id,
+      expect.objectContaining({ status: 'checking' }),
+    )
+    expect(harness.store.setAccountCheckResult).not.toHaveBeenCalledWith(
+      active.id,
+      expect.anything(),
+    )
+
+    resolveProbe(new Response('{}', { status: 200 }))
+    await vi.waitFor(() => expect(disabled.status).toBe('active'))
+    expect(disabled).toMatchObject({
+      status: 'active',
+      circuitState: 'closed',
+      consecutiveFailures: 0,
+      lastError: undefined,
+    })
+
+    // A duplicate zero-candidate signal cannot re-probe the now-active source.
+    harness.emitRuntimeState(update)
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(upstreamFetch).toHaveBeenCalledOnce()
+  })
+
   it('cools an exhausted OAuth account until the reset reported by the usage probe', async () => {
     const oauth = oauthAccount()
     const resetAfterSeconds = 3_600


### PR DESCRIPTION
## Summary
- make client-instance launch-mode expectations follow the host platform
- recheck only stale disabled/failure-cooled accounts after a zero-candidate schedule
- disable setup-go caching for the standalone corresponding-source job
- verify packaged sing-box manifests, hashes, POSIX executable bits, version/config, real start/stop, closed listeners, and no leftover process on every runtime target

## Verification
- npm exec vitest run tests/client-instances/client-instance-manager.test.ts (10 passed)
- npm exec vitest run tests/gateway/server.test.ts tests/ipc/gateway-api.test.ts (203 passed)
- npm test (1094 passed, 1 skipped)
- npm run lint
- npm run typecheck
- npm run build
- npm run sing-box:verify
- packaged Windows sing-box smoke test
- npm run release:check -- v0.9.5